### PR TITLE
bugfix: <Plug>(vimfiler_edit_file) and <Plug>(vimfiler_split_edit_file) were opposite

### DIFF
--- a/autoload/vimfiler/mappings.vim
+++ b/autoload/vimfiler/mappings.vim
@@ -432,7 +432,7 @@ function! s:edit_file(is_split)"{{{
 
   let l:file = vimfiler#get_file(line('.'))
   call unite#mappings#do_action(
-        \ (a:is_split ? g:vimfiler_edit_action : g:vimfiler_split_action), [l:file])
+        \ (a:is_split ? g:vimfiler_split_action : g:vimfiler_edit_action), [l:file])
 endfunction"}}}
 function! s:edit_binary_file(is_split)"{{{
   if !vimfiler#check_filename_line()


### PR DESCRIPTION
bugfix: <Plug>(vimfiler_edit_file) and <Plug>(vimfiler_split_edit_file) were opposite
