### PR TITLE
minor change to vimfiler prompt syntax display

### DIFF
--- a/syntax/vimfiler.vim
+++ b/syntax/vimfiler.vim
@@ -82,14 +82,15 @@ else
 endif
 
 if has('gui_running')
-    hi vimfilerCurrentDirectory  gui=UNDERLINE guifg=#80ffff guibg=NONE
+    hi vimfilerCurrentDirectory  guifg=#80ffff guibg=NONE
 else
     hi def link vimfilerCurrentDirectory Identifier
 endif
 hi def link vimfilerMask Statement
 
 hi def link vimfilerSpecial Special
-hi def link vimfilerSpecialSafe Statement
+hi vimfilerSpecialSafe guifg=red ctermfg=red
+
 hi def link vimfilerNonMark Special
 "hi vimfilerMarkedFile  gui=REVERSE term=REVERSE
 hi def link vimfilerMarkedFile Type


### PR DESCRIPTION
1. vimfilerCurrentDirectory : underline is not pretty when crossing multiple lines
2. vimfilerSpecialSafe: simply use red to highlight **unsafe** status

P.S. maybe vimfilerSpecialSafe should be renamed as vimfilerSpecialUnSafe
