### PR TITLE
if exists vimfiler.winwidth

### DIFF
--- a/autoload/vimfiler.vim
+++ b/autoload/vimfiler.vim
@@ -944,8 +944,10 @@ function! s:event_bufwin_enter(bufnr)"{{{
   endif
 
   let winwidth = (winwidth(0)+1)/2*2
-  if vimfiler.winwidth != winwidth
-    call vimfiler#redraw_screen()
+  if exists('vimfiler.winwidth')
+      if vimfiler.winwidth != winwidth
+        call vimfiler#redraw_screen()
+      endif
   endif
 
   if exists('winnr')


### PR DESCRIPTION
without this, over ssh, I get 

```
E716: Key not present in Dictionary: winwidth != winwidth                                 
E15: Invalid expression: vimfiler.winwidth != winwidth 
```
