### PR TITLE
Fix s:on_double_click behavior

### DIFF
--- a/autoload/vimfiler/mappings.vim
+++ b/autoload/vimfiler/mappings.vim
@@ -1522,7 +1522,7 @@ function! s:on_double_click() "{{{
     if vimfiler#get_filename() ==# '..'
       call vimfiler#mappings#cd('..')
     else
-      call s:execute_system_associated()
+      call s:edit()
     endif
   else
     call s:toggle_tree(0)

--- a/doc/vimfiler.txt
+++ b/doc/vimfiler.txt
@@ -713,7 +713,7 @@ Normal mode key mappings.
 		If cursor is on the directory, execute
 		|<Plug>(vimfiler_expand_tree)| mapping.
 		If cursor is on the file, execute
-		|<Plug>(vimfiler_execute_system_associated)| mapping.
+		|<Plug>(vimfiler_edit_file)| mapping.
 
 <Plug>(vimfiler_quick_look)		*<Plug>(vimfiler_quick_look)*
 		Preview the file by |g:vimfiler_quick_look_command|.


### PR DESCRIPTION
First commit fixes a bug introduced in https://github.com/Shougo/vimfiler.vim/commit/7c422c179c9548b5ae01e563768a2059bb0cca6b.
Second commit changes behavior of double-click on file.
File is opened in local buffer instead of new window.
In my opinion, this is saner.
