### PR TITLE
nnoremap とすべきところが nmap になっていたのを修正

### DIFF
--- a/autoload/vimfiler/mappings.vim
+++ b/autoload/vimfiler/mappings.vim
@@ -166,11 +166,11 @@ function! vimfiler#mappings#define_default_mappings(context) "{{{
         \ :<C-u>call <SID>cd_input_directory()<CR>
   nnoremap <buffer><silent> <Plug>(vimfiler_double_click)
         \ :<C-u>call <SID>on_double_click()<CR>
-  nmap <buffer><silent> <Plug>(vimfiler_quick_look)
+  nnoremap <buffer><silent> <Plug>(vimfiler_quick_look)
         \ :<C-u>call <SID>quick_look()<CR>
-  nmap <buffer><silent> <Plug>(vimfiler_jump_first_child)
+  nnoremap <buffer><silent> <Plug>(vimfiler_jump_first_child)
         \ :<C-u>call <SID>jump_child(1)<CR>
-  nmap <buffer><silent> <Plug>(vimfiler_jump_last_child)
+  nnoremap <buffer><silent> <Plug>(vimfiler_jump_last_child)
         \ :<C-u>call <SID>jump_child(0)<CR>
 
   if b:vimfiler.is_safe_mode


### PR DESCRIPTION
はじめまして。neetularと申します。
Shougoさんのプラグインを多数日々便利に使わせていただいております。ありがとうございます。

g:vimfiler_quick_look_command をセットしてクイックルックをしたかったのですが、うまく動かなかったのがきっかけで今回のバグを調査、修正しました。

私は .vimrc で

```
nmap :  <Plug>(vimshell_switch)
```

としているので、クイックルックしようとするとvimshell画面になってエラー扱いになり、しばらく謎でした。
マージをお願いできれば幸いです。

ちなみにこれと関連して、私はMacを使っておりますが

```
let g:vimfiler_quick_look_command = 'qlmanage -p'
```

と設定しても、executableのチェックに引っかかって動きません。
下記チェック部分をコメントアウトすると正常に動くことは確認できました。

https://github.com/Shougo/vimfiler.vim/blob/a7106a1aadb83d28a54f89319ebf2fa85d621438/autoload/vimfiler/mappings.vim#L1549-1554

qlmanageに限らず、executable() に -p のようなオプション付きのコマンドを渡すと0が帰ってくるようです。

:echo executable('qlmanage -p') → 0
:echo executable('qlmanage') → 1

環境によって違うことなのかもしれませんがひとまずご報告とさせていただきます。

この件でなにかご協力できることがあれば可能な限りお力になりたいと思います。

ご確認のほどよろしくお願いいたします。
