### PR TITLE
Added option to enable jumping to first child

### DIFF
--- a/autoload/vimfiler/init.vim
+++ b/autoload/vimfiler/init.vim
@@ -72,6 +72,8 @@ let g:vimfiler_explorer_columns =
       \ get(g:, 'vimfiler_explorer_columns', 'type')
 let g:vimfiler_ignore_pattern =
       \ get(g:, 'vimfiler_ignore_pattern', '^\.')
+let g:vimfiler_expand_jump_to_first_child =
+      \ get(g:, 'vimfiler_expand_jump_to_first_child', 1)
 
 let g:vimfiler_execute_file_list =
       \ get(g:, 'vimfiler_execute_file_list', {})

--- a/autoload/vimfiler/mappings.vim
+++ b/autoload/vimfiler/mappings.vim
@@ -918,7 +918,7 @@ function! s:expand_tree(is_recursive) "{{{
 
   setlocal nomodifiable
 
-  if !a:is_recursive && !is_fold
+  if g:vimfiler_expand_jump_to_first_child && !a:is_recursive && !is_fold
     " Move to next line.
     call cursor(line('.') + 1, 0)
   endif

--- a/doc/vimfiler.txt
+++ b/doc/vimfiler.txt
@@ -359,6 +359,13 @@ g:vimfiler_ignore_pattern			 *g:vimfiler_ignore_pattern*
 <
 		Default value is '^\.' (dot files pattern).
 
+					*g:vimfiler_expand_jump_to_first_child*
+g:vimfiler_expand_jump_to_first_child			 
+		This variable controls if you jump to the first child when you
+		expand a directory tree.
+		
+		Default value is 1.
+
 						*g:vimfiler_draw_files_limit*
 g:vimfiler_draw_files_limit
 		Specify the limit of redraw files.


### PR DESCRIPTION
This options lets you set if you want to automatically jump to the first child
when you expand a directory tree.
