### PR TITLE
Add more explanation to key mapping <Plug>(vimfiler_mark_similar_lines)

### DIFF
--- a/doc/vimfiler.txt
+++ b/doc/vimfiler.txt
@@ -481,7 +481,15 @@ Normal mode key mappings.
 
 				*<Plug>(vimfiler_mark_similar_lines)*
 <Plug>(vimfiler_mark_similar_lines)
-		Mark similar files with cursor file.
+		Mark files similar to the cursor file.  You can consider a
+		line to be similar when you can find both the file name and the
+		extension in that line.  For example, use this when you want to
+		mark files `foo1.txt`, `foo2_tmp.txt`, `foo35.txt.bak` but not
+		`foo.md` or `bar1.txt` etc.
+
+		More precisely, for those who know regex, it replaces the
+		non-|identifier| characters in the file name with the regular
+		expression `.\+` and looks for files that match.
 
 				*<Plug>(vimfiler_clear_mark_all_lines)*
 <Plug>(vimfiler_clear_mark_all_lines)


### PR DESCRIPTION
# 203の件です。とりあえず書いてみました。

いつマッチするのかを正確に説明する必要はないと思ったので(`fo1o.txt`が`fo1baro.txt`にはマッチするが`fo1bar.otxt`にはマッチしないなど)、おそらく想定された使用例を足しました。
