### PR TITLE
Enable -project option also in switching to existing vimfiler buffer

### DIFF
--- a/autoload/vimfiler/init.vim
+++ b/autoload/vimfiler/init.vim
@@ -359,6 +359,10 @@ function! vimfiler#init#_start(path, ...) "{{{
     endif
   endif
 
+  if context.project
+    let path = vimfiler#util#path2project_directory(path)
+  endif
+
   if !context.create
     " Search vimfiler buffer.
     for bufnr in filter(insert(range(1, bufnr('$')), bufnr('%')),


### PR DESCRIPTION
I can open project home (in which `.git` directory exists) with `:VimFiler -project` in first time,
but I cannot in second time.
It seems that `-project` option does not work when `:VimFiler` opens existing vimfiler buffer.
I found `vimfiler#init#_switch_vimfiler` does not check `context.project` and fixed it.
