### PR TITLE
vimfiler can't close an existing vimfiler when the vimfiler buffer has multiple filetypes.

### DIFF
--- a/autoload/vimfiler/init.vim
+++ b/autoload/vimfiler/init.vim
@@ -377,7 +377,7 @@ function! vimfiler#init#_start(path, ...) "{{{
     " Search vimfiler buffer.
     for bufnr in filter(insert(range(1, bufnr('$')), bufnr('%')),
           \ "bufloaded(v:val) &&
-          \ getbufvar(v:val, '&filetype') ==# 'vimfiler'")
+          \ getbufvar(v:val, '&filetype') =~# 'vimfiler'")
       let vimfiler = getbufvar(bufnr, 'vimfiler')
       if type(vimfiler) == type({})
             \ && vimfiler.context.buffer_name ==# context.buffer_name

--- a/autoload/vimfiler/util.vim
+++ b/autoload/vimfiler/util.vim
@@ -228,7 +228,7 @@ function! vimfiler#util#convert2list(expr) "{{{
 endfunction"}}}
 function! vimfiler#util#get_vimfiler_winnr(buffer_name) "{{{
   for winnr in filter(range(1, winnr('$')),
-        \ "getbufvar(winbufnr(v:val), '&filetype') ==# 'vimfiler'")
+        \ "getbufvar(winbufnr(v:val), '&filetype') =~# 'vimfiler'")
     let buffer_context = getbufvar(
           \ winbufnr(winnr), 'vimfiler').context
     if buffer_context.buffer_name ==# a:buffer_name


### PR DESCRIPTION
vimfiler can't close a window correctly when the window has multiple filetypes. For example, `&filetype` is `project.vimfiler`. The root cause is that `vimfiler#util#get_vimfiler_winnr` can't return winnr if a buffer has multiple filetypes(because get_vimfiler_winnr compares filetypes using `==#` on closing a vimfiler window.). I think that comparing filetypes with regexp fixes this issue.
