### PR TITLE
Exclude quickfix window from choosewin windows

### DIFF
--- a/autoload/vimfiler/mappings.vim
+++ b/autoload/vimfiler/mappings.vim
@@ -628,6 +628,8 @@ function! s:switch() "{{{
   endif
 
   let windows = unite#helper#get_choose_windows()
+  let windows = filter(windows, "getwinvar(v:val, '&filetype') !=# 'qf'")
+
   if empty(windows)
     rightbelow vnew
   elseif len(windows) == 1


### PR DESCRIPTION
I think quickfix window is not used as file edit window, so I believe it makes sense to ignore it when choosing windows for file opening.

With this change, this thing never happens, vimfiler will just open file in main window:

<img width="1635" alt="screen shot 2015-11-23 at 19 15 32" src="https://cloud.githubusercontent.com/assets/665846/11337355/33d04a16-920e-11e5-8b2a-57c583e5c521.png">
