### PR TITLE
Fix #408 edit a binary file with vinarium fails from an explorer buffer

### DIFF
--- a/autoload/vimfiler/mappings.vim
+++ b/autoload/vimfiler/mappings.vim
@@ -1195,9 +1195,10 @@ function! s:edit_binary_file() abort "{{{
     return
   endif
 
+  let l:filename = vimfiler#get_filename()
   call s:switch()
 
-  execute 'Vinarise' escape(vimfiler#get_filename(), ' ')
+  execute 'Vinarise' escape(l:filename, ' ')
 endfunction"}}}
 function! s:execute_shell_command() abort "{{{
   let marked_files = vimfiler#get_marked_files(b:vimfiler)


### PR DESCRIPTION
When trying to open a binary file from a split VimFiler window, opened with `:VimFilerExplorer`, vinarium fails to open and throws an error, as reported in issue #408.

The value of `b:vimfiler` is undefined after calling  `s:switch()` and this is causing the bug. Getting the filename before calling `switch()` solves the problem, as `b:vimfiler` is still defined before switching.