### PR TITLE
Don't accidentally globally disable swapfiles

### DIFF
--- a/autoload/vimfiler/init.vim
+++ b/autoload/vimfiler/init.vim
@@ -529,7 +529,7 @@ function! s:create_vimfiler_buffer(path, context) abort
   endif
 
   " Save swapfile option.
-  let swapfile_save = &swapfile
+  let swapfile_save = &l:swapfile
 
   if !exists('t:vimfiler')
     let t:vimfiler = {}
@@ -538,10 +538,10 @@ function! s:create_vimfiler_buffer(path, context) abort
   let t:vimfiler[bufnr('%')] = 1
 
   try
-    set noswapfile
+    setlocal noswapfile
     let loaded = s:manager.open(bufname, 'silent edit')
   finally
-    let &g:swapfile = swapfile_save
+    let &l:swapfile = swapfile_save
   endtry
 
   let t:vimfiler[bufnr('%')] = 1


### PR DESCRIPTION
I encountered this bug recently while using SpaceVim/SpaceVim which uses
mhinz/vim-startify and Shougo/vimfiler. After opening neovim with no
arguments (which opens up the vimfiler and vim-startify buffer), any
file that I opened after that had no swap file. After working with
@mhinz on SpaceVim/SpaceVim#2966, we narrowed down the issue to the
section of code patched here.

Here's his synopsis:

> Mind the difference between &swapfile (prefers local value) and
> `&g:swapfile` (global value).
>
> When Startify runs first, it sets the local `&swapfile` to `0` without
> changing its global value, which is still `1`. Then vimfiler runs and
> temporarily saves the current local value `0`, but it doesn't restore the
> local but the global value afterwards. The let
> `&g:swapfile =  swapfile_save` is basically the same as
> `:setglobal noswapfile` or `:set noswapfile`, which will effects all
> other buffers opened later on.

I'm not super familiar with vimscript and the vimfiler code, so I'm not
sure if this fix has some unintended side effect against the intention
of function, and so I'm very much open to feedback.