### PR TITLE
Bugfix: fix broken sign command

### DIFF
--- a/autoload/vimfiler/view.vim
+++ b/autoload/vimfiler/view.vim
@@ -324,7 +324,7 @@ function! vimfiler#view#_get_max_len(files) abort
 
   if has('signs')
     " Delete signs.
-    silent execute 'sign unplace buffer='.bufnr('%')
+    silent execute 'sign unplace * buffer='.bufnr('%')
   endif
 
   let max_len = max([winwidth(0) - padding, 10])


### PR DESCRIPTION
In nvim v0.11.0-dev, `sign` command without `{id}` or `*` raises an exception.
I have not investigated which change in neovim are occurred this bug.

```
...
:48: VimEnter Autocommands for "*"..script nvim_exec2() called at VimEnter Autocommands for "*":0..function vimfiler#i
nit#_command[22]..vimfiler#init#_start[63]..<SNR>100_create_vimfiler_buffer[67]..vimfiler#handler#_event_handler[15]..
<SNR>126_on_BufReadCmd[23]..vimfiler#init#_vimfiler_directory[64]..vimfiler#view#_force_redraw_all_vimfiler[10]..vimfi
ler#view#_force_redraw_screen[61]..vimfiler#view#_redraw_screen[47]..vimfiler#view#_get_print_lines[8]..vimfiler#view#
_get_max_len, line 24: Vim(sign):E159: Missing sign number
```